### PR TITLE
Fix Get Storage Key

### DIFF
--- a/AzureRM - Get VNET Gateway Logs.ps1
+++ b/AzureRM - Get VNET Gateway Logs.ps1
@@ -65,7 +65,7 @@ $storageAccountKey =
     ( Get-AzureRmStorageAccountKey `
           -Name $storageAccountName `
           -ResourceGroupName $rgName
-    ).Key1
+    ).Value[0]
 
 # STEP 8: Sign-in to Azure via Azure Service Management
 


### PR DESCRIPTION
doesnt work because of selector ".Key1", what works is: ".Value[0]"
# STEP 7: Get Key for Azure Storage Account

$storageAccountKey = 
    ( Get-AzureRmStorageAccountKey `
          -Name $storageAccountName`
          -ResourceGroupName $rgName
    ).**Key1**
