### PR TITLE
Fix for authentication dialog and headers

### DIFF
--- a/MicrosoftAzureServiceFabric-AADHelpers/AADTool/Common.ps1
+++ b/MicrosoftAzureServiceFabric-AADHelpers/AADTool/Common.ps1
@@ -27,8 +27,8 @@ function GetRESTHeaders()
     $redirectUrl = "urn:ietf:wg:oauth:2.0:oob"
     
     $authenticationContext = New-Object Microsoft.IdentityModel.Clients.ActiveDirectory.AuthenticationContext -ArgumentList $authString, $FALSE
-
-    $accessToken = $authenticationContext.AcquireToken($resourceUrl, $clientId, $redirectUrl, [Microsoft.IdentityModel.Clients.ActiveDirectory.PromptBehavior]::RefreshSession).AccessToken
+    $parameters = [Microsoft.IdentityModel.Clients.ActiveDirectory.PlatformParameters]::new([Microsoft.IdentityModel.Clients.ActiveDirectory.PromptBehavior]::RefreshSession)
+    $accessToken = $authenticationContext.AcquireTokenAsync($resourceUrl, $clientId, $redirectUrl, $parameters).Result.AccessToken
     $headers = New-Object "System.Collections.Generic.Dictionary[[String],[String]]"
     $headers.Add("Authorization", $accessToken)
     return $headers


### PR DESCRIPTION
Fix for auth headers not being parsed due to missing method AquireToken

Microsoft.IdentityModel.Clients.ActiveDirectory.AuthenticationContext now has a method called AquireTokenAsync for .NET Core. So use this method instead.