### PR TITLE
Fix oauth2permissions on app create

### DIFF
--- a/MicrosoftAzureServiceFabric-AADHelpers/AADTool/Common.ps1
+++ b/MicrosoftAzureServiceFabric-AADHelpers/AADTool/Common.ps1
@@ -37,10 +37,10 @@ function GetRESTHeaders()
     return $headers
 }
 
-function CallGraphAPI($uri, $headers, $body)
+function CallGraphAPI($uri, $headers, $body, $method = "Post")
 {
     $json = $body | ConvertTo-Json -Depth 4 -Compress
-    return (Invoke-RestMethod $uri -Method Post -Headers $headers -Body $json -ContentType "application/json")
+    return (Invoke-RestMethod $uri -Method $method -Headers $headers -Body $json -ContentType "application/json")
 }
 
 function AssertNotNull($obj, $msg){


### PR DESCRIPTION
Updates the logic when creating the web app's Application object, to update the newly-created object—to add an `oauth2Permissions` value for the "user_impersonation" scope—*only* if this scope was not already added by default.